### PR TITLE
최근 검색 기록 기능

### DIFF
--- a/app/src/main/java/com/example/yeseul/movieapp/RecentSearchWordVM.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/RecentSearchWordVM.java
@@ -1,0 +1,31 @@
+package com.example.yeseul.movieapp;
+
+import android.databinding.BaseObservable;
+import android.databinding.BindingAdapter;
+import android.util.Log;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.example.yeseul.movieapp.data.model.RecentSearchWord;
+
+import java.util.ArrayList;
+
+public class RecentSearchWordVM extends BaseObservable {
+    private RecentSearchWord recentSearchWord;
+
+    public RecentSearchWordVM(RecentSearchWord recentSearchWord) {
+        this.recentSearchWord = recentSearchWord;
+    }
+
+    public RecentSearchWord getRecentSearchWord() {
+        return recentSearchWord;
+    }
+
+    @BindingAdapter(value ="date")
+    static public void setDateText(TextView textView, String date){
+        Log.d("onFocus",date);
+        textView.setText(date);
+    }
+}

--- a/app/src/main/java/com/example/yeseul/movieapp/data/model/RecentSearchWord.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/data/model/RecentSearchWord.java
@@ -1,0 +1,28 @@
+package com.example.yeseul.movieapp.data.model;
+
+public class RecentSearchWord {
+    private String movieName;
+    private String date;
+
+    public RecentSearchWord(String movieName, String date) {
+        this.movieName = movieName;
+        this.date = date;
+    }
+
+    public String getMovieName() {
+        return movieName;
+    }
+
+    public void setMovieName(String movieName) {
+        this.movieName = movieName;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+}

--- a/app/src/main/java/com/example/yeseul/movieapp/utils/BindingUtil.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/utils/BindingUtil.java
@@ -3,21 +3,27 @@ package com.example.yeseul.movieapp.utils;
 import android.databinding.BindingAdapter;
 import android.databinding.BindingConversion;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.util.Log;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.RatingBar;
 import android.widget.TextView;
 
 import okhttp3.Interceptor;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
 
 public class BindingUtil {
 
     @BindingConversion
     public static int setVisibility(boolean isVisible){
 
-        return isVisible ? View.VISIBLE : View.GONE;
+        return isVisible ? View.VISIBLE : GONE;
     }
 
     @BindingAdapter({"rating"})

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
@@ -1,25 +1,49 @@
 package com.example.yeseul.movieapp.view.main;
 
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.Observer;
+import android.databinding.BindingAdapter;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.TextUtils;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
 
+import com.example.yeseul.movieapp.BR;
 import com.example.yeseul.movieapp.R;
+import com.example.yeseul.movieapp.data.model.RecentSearchWord;
 import com.example.yeseul.movieapp.data.source.movie.MovieRepository;
 import com.example.yeseul.movieapp.databinding.ActivityMovieBinding;
 import com.example.yeseul.movieapp.utils.KeyboardUtil;
 import com.example.yeseul.movieapp.view.BaseActivity;
 
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Stack;
+
+import io.reactivex.Observable;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+
 public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresenter> implements MainContract.View {
 
     private MovieListAdapter adapter;
+    private RecentSearchAdapter recentSearchAdapter;
+    private ArrayList<RecentSearchWord> recentSearchWords = new ArrayList<>();
+    private MutableLiveData<Boolean> searchBoxFlagLiveData = new MutableLiveData<>();
 
     @Override
     protected int getLayoutId() {
@@ -36,18 +60,31 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
         super.onCreate(savedInstanceState);
 
         adapter = new MovieListAdapter(this);
+
         presenter.setAdapterView(adapter);
         presenter.setAdapterModel(adapter);
 
         binding.setPresenter(presenter);
 
+        recentSearchAdapter = new RecentSearchAdapter(recentSearchWords, this, binding.searchBox.etSearch);
+        binding.searchBox.setVariable(BR.recent_search_adapter, recentSearchAdapter);
+
         initView();
 
         presenter.onViewCreated();
+
+        searchBoxFlagLiveData.observe(this, flag -> {
+            if (flag) {
+                binding.searchBox.rvRecent.setVisibility(VISIBLE);
+                binding.viewTranslate.setVisibility(VISIBLE);
+            } else {
+                binding.searchBox.rvRecent.setVisibility(GONE);
+                binding.viewTranslate.setVisibility(GONE);
+            }
+        });
     }
 
     private void initView() {
-
         // recyclerView 생성
         binding.recyclerMovie.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
         binding.recyclerMovie.setAdapter(adapter);
@@ -56,11 +93,11 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
         binding.recyclerMovie.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
 
         // 최하단 스크롤 감지
-        binding.recyclerMovie.setOnScrollListener(new RecyclerView.OnScrollListener(){
+        binding.recyclerMovie.setOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
             public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
-                if(!binding.recyclerMovie.canScrollVertically(1)){
+                if (!binding.recyclerMovie.canScrollVertically(1)) {
                     presenter.loadItems(false);
                 }
             }
@@ -68,37 +105,70 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
 
         // 키보드 검색 버튼 리스너 등록
         binding.searchBox.etSearch.setOnEditorActionListener((v, actionId, event) -> {
-            if(actionId == EditorInfo.IME_ACTION_SEARCH){
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                 onSearchButtonClicked();
                 return true;
             }
             return false;
         });
-
+        binding.searchBox.etSearch.setOnClickListener(v -> searchBoxFlagLiveData.setValue(true));
+        binding.viewTranslate.setOnClickListener(v -> searchBoxFlagLiveData.setValue(false));
         // 검색 버튼 리스너 등록
         binding.searchBox.btnSubmit.setOnClickListener(v -> onSearchButtonClicked());
     }
 
     /**
-     * 키보드 검색 혹은 검색 버튼 눌렀을 때 호출 */
-    private void onSearchButtonClicked(){
+     * 키보드 검색 혹은 검색 버튼 눌렀을 때 호출
+     */
+    private void onSearchButtonClicked() {
 
         // 입력값이 존재 하는지 체크
         String searchKey = binding.searchBox.etSearch.getText().toString();
 
-        if(!TextUtils.isEmpty(searchKey)) {
+        if (!TextUtils.isEmpty(searchKey)) {
             presenter.onSearchButtonClicked(searchKey);
             binding.recyclerMovie.scrollToPosition(0);
             binding.emptyView.setText("");
+            searchBoxFlagLiveData.setValue(false);
+            makeSearchInfo(searchKey);
             KeyboardUtil.closeKeyboard(this, binding.searchBox.etSearch);
-
         } else {
             makeToast(getString(R.string.search_hint));
         }
     }
 
+    private void makeSearchInfo(String searchKey) {
+        Date cDate = new Date();
+        String MMdd = new SimpleDateFormat("MM-dd").format(cDate);
+        RecentSearchWord recentSearchWord = new RecentSearchWord(searchKey, MMdd);
+        boolean compareFlag = false;
+        int comparePosition = 0;
+        for (int i=0; i<recentSearchWords.size(); i++){
+            if(recentSearchWords.get(i).getMovieName().equals(searchKey)){
+                compareFlag = true;
+                comparePosition = i;
+                break;
+            }
+        }
+        if (compareFlag) {
+            recentSearchWords.remove(comparePosition);
+            recentSearchWords.add(0, recentSearchWord);
+        }else{
+            recentSearchWords.add(0, recentSearchWord);
+        }
+        if (recentSearchWords.size() < 5){
+            if(compareFlag)
+                recentSearchAdapter.notifyItemRangeChanged(0, recentSearchWords.size());
+            else
+                recentSearchAdapter.notifyItemInserted(0);
+        }
+        else
+            recentSearchAdapter.notifyItemRangeChanged(0, 5);
+    }
+
     /**
-     * 검색 결과가 없는 경우 presenter 에 의해 호출됨 */
+     * 검색 결과가 없는 경우 presenter 에 의해 호출됨
+     */
     @Override
     public void onSearchResultEmpty(String searchKey) {
 
@@ -108,7 +178,8 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
     }
 
     /**
-     * 영화 상세 정보 URL 로 연결 */
+     * 영화 상세 정보 URL 로 연결
+     */
     @Override
     public void startMovieDetailPage(String linkUrl) {
 

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
@@ -39,7 +39,6 @@ public class MainPresenter implements MainContract.Presenter {
 
     @Override
     public void loadItems(boolean isRefresh) {
-
         // refresh true 의 경우 초기화
         if (isRefresh){
             currentPage = 0;

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/RecentSearchAdapter.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/RecentSearchAdapter.java
@@ -1,0 +1,76 @@
+package com.example.yeseul.movieapp.view.main;
+
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+
+import com.example.yeseul.movieapp.BR;
+import com.example.yeseul.movieapp.R;
+import com.example.yeseul.movieapp.RecentSearchWordVM;
+import com.example.yeseul.movieapp.data.model.RecentSearchWord;
+import com.example.yeseul.movieapp.databinding.SearchWordListItemBinding;
+
+import java.util.ArrayList;
+
+public class RecentSearchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private ArrayList<RecentSearchWord> recentSearchWords = new ArrayList<>();
+    private Context mContext = null;
+    private EditText etSearch = null;
+
+    public RecentSearchAdapter(ArrayList<RecentSearchWord> recentSearchWords, Context mContext, EditText etSearch) {
+        this.recentSearchWords = recentSearchWords;
+        this.mContext = mContext;
+        this.etSearch = etSearch;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int i) {
+        SearchWordListItemBinding searchWordListItemBinding = DataBindingUtil.inflate(LayoutInflater.from(mContext), R.layout.search_word_list_item, viewGroup, false);
+        return new RecentSearchWordHolder(searchWordListItemBinding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
+        RecentSearchWordHolder recentSearchWordHolder = (RecentSearchWordHolder)viewHolder;
+        recentSearchWordHolder.searchWordListItemBinding.setVariable(BR.vm_recent_search_word, new RecentSearchWordVM(recentSearchWords.get(position)));
+        recentSearchWordHolder.searchWordListItemBinding.itemLL.setOnClickListener(view -> {
+            Log.d("position",String.valueOf(viewHolder.getAdapterPosition()));
+            etSearch.setText("");
+            etSearch.setText(recentSearchWords.get(viewHolder.getAdapterPosition()).getMovieName());
+            RecentSearchWord recentSearchWord = recentSearchWords.get(viewHolder.getAdapterPosition());
+            RecentSearchWord tempSearchWord = recentSearchWords.get(0);
+            recentSearchWords.set(0, recentSearchWord);
+            recentSearchWords.set(viewHolder.getAdapterPosition(), tempSearchWord);
+            notifyItemChanged(0);
+            notifyItemChanged(viewHolder.getAdapterPosition());
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        if(recentSearchWords.size()>5){
+            return 5;
+        }
+        return recentSearchWords.size();
+    }
+
+    class RecentSearchWordHolder extends RecyclerView.ViewHolder{
+        private SearchWordListItemBinding searchWordListItemBinding = null;
+
+        RecentSearchWordHolder(SearchWordListItemBinding searchWordListItemBinding) {
+            super(searchWordListItemBinding.getRoot().getRootView());
+            this.searchWordListItemBinding = searchWordListItemBinding;
+        }
+
+        SearchWordListItemBinding getSearchWordListItemBinding() {
+            return searchWordListItemBinding;
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_history_clock_button.xml
+++ b/app/src/main/res/drawable/ic_history_clock_button.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:viewportHeight="510"
+    android:viewportWidth="510" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="0.9" android:fillColor="#959a9e"
+        android:pathData="M267.75,12.75c-89.25,0 -168.3,48.45 -209.1,122.4L0,76.5v165.75h165.75l-71.4,-71.4c33.15,-63.75 96.9,-107.1 173.4,-107.1C372.3,63.75 459,150.45 459,255s-86.7,191.25 -191.25,191.25c-84.15,0 -153,-53.55 -181.05,-127.5H33.15c28.05,102 122.4,178.5 234.6,178.5C402.9,497.25 510,387.6 510,255C510,122.4 400.35,12.75 267.75,12.75zM229.5,140.25V270.3l119.85,71.4l20.4,-33.15l-102,-61.2v-107.1H229.5z" android:strokeAlpha="0.9"/>
+</vector>

--- a/app/src/main/res/layout/activity_movie.xml
+++ b/app/src/main/res/layout/activity_movie.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:bind="http://schemas.android.com/tools">
 
     <data>
@@ -8,43 +9,57 @@
             type="com.example.yeseul.movieapp.view.main.MainPresenter"/>
     </data>
 
-    <LinearLayout
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <include
-            android:id="@+id/search_box"
-            layout="@layout/layout_search_box"
-            bind:presenter="@{presenter}"/>
-
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
+            android:layout_height="match_parent"
+            android:layout_marginTop="?attr/actionBarSize"
+            app:layout_constraintTop_toTopOf="parent">
 
             <com.example.yeseul.movieapp.view.custom.EmptyRecyclerView
                 android:id="@+id/recycler_movie"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:overScrollMode="never"/>
+                android:overScrollMode="never" />
 
             <TextView
                 android:id="@+id/empty_view"
-                android:padding="@dimen/padding_main"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:gravity="center"
+                android:padding="@dimen/padding_main"
                 android:textColor="@android:color/black"
-                android:textSize="@dimen/text_size_main"/>
+                android:textSize="@dimen/text_size_main" />
 
             <ProgressBar
                 android:id="@+id/loading"
-                android:visibility="@{presenter.isLoading}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"/>
+                android:layout_gravity="center"
+                android:visibility="@{presenter.isLoading}" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/transparent_black"
+                android:visibility="gone"
+                android:orientation="horizontal"
+                android:id="@+id/view_translate"></LinearLayout>
         </FrameLayout>
-    </LinearLayout>
+
+        <include
+            android:id="@+id/search_box"
+            layout="@layout/layout_search_box"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            bind:presenter="@{presenter}" />
+    </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/layout_search_box.xml
+++ b/app/src/main/res/layout/layout_search_box.xml
@@ -1,44 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
-
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <data>
         <variable
             name="presenter"
             type="com.example.yeseul.movieapp.view.main.MainPresenter"/>
+        <variable
+            name="recent_search_adapter"
+            type="com.example.yeseul.movieapp.view.main.RecentSearchAdapter"/>
     </data>
-
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="@drawable/line_bottom"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:elevation="2dp">
 
-        <EditText
-            android:id="@+id/et_search"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@drawable/line_bottom"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <EditText
+                android:id="@+id/et_search"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="match_parent"
+                android:layout_marginLeft="@dimen/padding_main"
+                android:layout_marginStart="@dimen/padding_main"
+                android:background="@null"
+                android:inputType="text"
+                android:singleLine="true"
+                android:imeOptions="actionSearch"
+                android:hint="@string/search_hint"
+                android:textColor="@android:color/black"
+                android:textSize="@dimen/text_size_main"
+                android:gravity="center_vertical"/>
+
+            <Button
+                android:id="@+id/btn_submit"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@null"
+                android:textColor="@color/colorPrimary"
+                android:textStyle="bold"
+                android:textSize="@dimen/text_size_main"
+                android:text="@string/search_submit"/>
+        </LinearLayout>
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/padding_main"
-            android:layout_marginStart="@dimen/padding_main"
-            android:background="@null"
-            android:inputType="text"
-            android:singleLine="true"
-            android:imeOptions="actionSearch"
-            android:hint="@string/search_hint"
-            android:textColor="@android:color/black"
-            android:textSize="@dimen/text_size_main"
-            android:gravity="center_vertical"/>
-
-        <Button
-            android:id="@+id/btn_submit"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@null"
-            android:textColor="@color/colorPrimary"
-            android:textStyle="bold"
-            android:textSize="@dimen/text_size_main"
-            android:text="@string/search_submit"/>
-
+            android:visibility="visible"
+            android:id="@+id/rv_recent"
+            android:background="@color/white_ffffff"
+            app:layoutManager="android.support.v7.widget.LinearLayoutManager"
+            android:adapter="@{recent_search_adapter}" />
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/search_word_list_item.xml
+++ b/app/src/main/res/layout/search_word_list_item.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="vm_recent_search_word"
+            type="com.example.yeseul.movieapp.RecentSearchWordVM"/>
+
+    </data>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="54dp"
+        android:orientation="horizontal"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:paddingLeft="16dp"
+        android:id="@+id/itemLL"
+        android:background="@color/white_ffffff">
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
+            app:srcCompat="@drawable/ic_history_clock_button"/>
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="5"
+            android:gravity="center_vertical"
+            android:textSize="16sp"
+            android:paddingLeft="12dp"
+            android:textColor="@color/black_000000"
+            android:text="@{vm_recent_search_word.recentSearchWord.movieName}"/>
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:gravity="center"
+            android:textSize="16sp"
+            date="@{vm_recent_search_word.recentSearchWord.date}"
+            />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,7 @@
     <color name="colorPrimaryDark">#88C4CC</color>
     <color name="colorAccent">#2DBEB4</color>
     <color name="colorDivider">#f2f2f2</color>
+    <color name="white_ffffff">#ffffff</color>
+    <color name="black_000000">#000000</color>
+    <color name="transparent_black">#70000000</color>
 </resources>


### PR DESCRIPTION
### 최근 검색 기록 기능
- 최근에 검색했던 영화의 이름을 기록해서 저장했습니다.
- 리스트에 검색했던 영화를 중복하지 않고, 최근에 검색한 검색어가 상단에 올라옵니다.
- 별도의 DB를 사용하지 않아서 일회용적으로 처리하고 있습니다.

### 상세 구현
![0](https://user-images.githubusercontent.com/22374750/51271559-36ed6200-1a0b-11e9-91b7-efac8107eb2f.gif)

### 주요 구현 방법

1. 최근 검색한 리스트의 이벤트 처리하기 

`etSearch`와 `view_translate` , `send` 를 클릭시에 `LiveData` 를 사용해서
boolean 값을 바꿀 때마다 최근 검색한 기록을 visible/gone을 시켜줍니다.

2. 최근 검색한 리스트의 알고리즘

- 최대 5개의 리스트의 값을 보여줍니다.
- for문을 통해서 해당 array에 특정 값이 있을 경우, 해당 position을 획득해서 아이템을 제거 후, 0번 째에 다시 아이템을 삽입.
- for문을 통해서 해당 array에 특정 값이 없다면, 0번 째에 아이템을 삽입.

### 더 해야할 것
- DB
- 아이템 클릭시에 바로 검색
- 아이템 삭제 구현