### PR TITLE
무한 스크롤링 호출 시점 변경

### DIFF
--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
@@ -20,6 +20,8 @@ import com.example.yeseul.movieapp.view.BaseActivity;
 public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresenter> implements MainContract.View {
 
     private MovieListAdapter adapter;
+    private LinearLayoutManager mLinearLayoutManager;
+    private final int UNVISIBLE = 5;
 
     @Override
     protected int getLayoutId() {
@@ -48,8 +50,9 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
 
     private void initView() {
 
+        mLinearLayoutManager = new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false);
         // recyclerView 생성
-        binding.recyclerMovie.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
+        binding.recyclerMovie.setLayoutManager(mLinearLayoutManager);
         binding.recyclerMovie.setAdapter(adapter);
         binding.recyclerMovie.setEmptyView(binding.emptyView);
         binding.recyclerMovie.setNestedScrollingEnabled(false);
@@ -60,7 +63,11 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
             @Override
             public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
-                if(!binding.recyclerMovie.canScrollVertically(1)){
+
+                int lastVisibleItemPos = mLinearLayoutManager.findLastVisibleItemPosition();
+                int itemCount = adapter.getItemCount();
+
+                if((itemCount > 0) && (UNVISIBLE + lastVisibleItemPos) > itemCount ){
                     presenter.loadItems(false);
                 }
             }

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
@@ -23,7 +23,7 @@ public class MainPresenter implements MainContract.Presenter {
     private AdapterContract.Model<Movie> adapterModel;
 
     private String searchKey = ""; // 검색 키워드
-    private final int PAGE_UNIT = 20; // 한번에 가져올 데이터 개수
+    private final int PAGE_UNIT = 10; // 한번에 가져올 데이터 개수
     private int currentPage = 0; // 현재 페이지 index
     private boolean isEndOfPage = false; // 페이지 끝 flag
 
@@ -41,10 +41,9 @@ public class MainPresenter implements MainContract.Presenter {
     public void loadItems(boolean isRefresh) {
 
         // refresh true 의 경우 초기화
-        if (isRefresh){
+        if (isRefresh) {
             currentPage = 0;
             isEndOfPage = false;
-            adapterModel.clearItems();
         }
 
         // 마지막 페이지가 아니고 로딩중 아닌 경우 getMovieList 호출
@@ -82,6 +81,11 @@ public class MainPresenter implements MainContract.Presenter {
 
                     // 로딩 flag OFF
                     isLoading.set(false);
+
+                    // 검색버튼에 의한 호출일 경우, 기존 list 비우기
+                    if(currentPage == 1) {
+                        adapterModel.clearItems();
+                    }
 
                     List<Movie> movieList = response.getMovieList();
 


### PR DESCRIPTION
### 개요
기존 무한 스크롤링 호출 시점은 저장된 아이템들 중 제일 마지막 아이템이 화면 바닥에 노출될 때입니다.
(수직으로 스크롤을 더 이상 할 수 없을 때)
사용자는 부드럽게 내려가던 스크롤이 갑자기 멈추는 경험을 합니다.
부드러운 움직임을 유지하고자 호출 시점을 저장되어 있던 아이템들 중 끝에서 5번째 아이템이 화면에 노출될 때로 수정했습니다.

### 작업사항

- **onScrollStateChanged** 함수 수정

- 무한 스크롤 호출 테스트를 위해 기본 호출 개수를 20개에서 10개로 수정

- 검색 버튼에 의한 list 수정을 call back 에서 후처리하도록 수정

감사합니다 ! :)
