### PR TITLE
API호출 관련 코드 수정.

### DIFF
--- a/app/src/main/java/com/example/yeseul/movieapp/data/source/movie/MovieRemoteDataSource.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/data/source/movie/MovieRemoteDataSource.java
@@ -29,7 +29,7 @@ public class MovieRemoteDataSource implements MovieDataSource{
 
         return RetrofitClient.getClient().create(MovieApi.class)
                 .searchMovies(request)
-                .subscribeOn(Schedulers.newThread());
+                .subscribeOn(Schedulers.io());
     }
 
 }

--- a/app/src/main/java/com/example/yeseul/movieapp/utils/GlideUtil.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/utils/GlideUtil.java
@@ -3,6 +3,8 @@ package com.example.yeseul.movieapp.utils;
 import android.databinding.BindingAdapter;
 import android.widget.ImageView;
 
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.example.yeseul.movieapp.R;
 
 public class GlideUtil {
@@ -20,7 +22,12 @@ public class GlideUtil {
 
         if (url == null) return;
 
-        GlideApp.with(imageView).load(url).placeholder(R.drawable.img_boostcamp).centerCrop().into(imageView);
+        GlideApp.with(imageView).load(url)
+                .placeholder(R.drawable.img_boostcamp)
+                .centerCrop()
+                .transition(DrawableTransitionOptions.withCrossFade())
+                .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+                .into(imageView);
     }
 
 }

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
@@ -48,19 +48,24 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
 
     private void initView() {
 
+        LinearLayoutManager layoutManager = new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false);
+
         // recyclerView 생성
-        binding.recyclerMovie.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
+        binding.recyclerMovie.setLayoutManager(layoutManager);
         binding.recyclerMovie.setAdapter(adapter);
         binding.recyclerMovie.setEmptyView(binding.emptyView);
         binding.recyclerMovie.setNestedScrollingEnabled(false);
         binding.recyclerMovie.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
 
         // 최하단 스크롤 감지
-        binding.recyclerMovie.setOnScrollListener(new RecyclerView.OnScrollListener(){
+        binding.recyclerMovie.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
             public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
-                if(!binding.recyclerMovie.canScrollVertically(1)){
+
+                int lastVisiblePosition = layoutManager.findLastCompletelyVisibleItemPosition();
+
+                if(adapter.getItemCount() <= lastVisiblePosition+5) {
                     presenter.loadItems(false);
                 }
             }

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
@@ -123,4 +123,18 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
 
         customTabsIntent.launchUrl(this, Uri.parse(linkUrl));
     }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+
+        presenter.clearDisposables();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        presenter.disposeDisposables(); //Presenter의 메소드 호출.
+    }
 }

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
@@ -23,7 +23,7 @@ public class MainPresenter implements MainContract.Presenter {
     private AdapterContract.Model<Movie> adapterModel;
 
     private String searchKey = ""; // 검색 키워드
-    private final int PAGE_UNIT = 20; // 한번에 가져올 데이터 개수
+    private final int PAGE_UNIT = 15; // 한번에 가져올 데이터 개수
     private int currentPage = 0; // 현재 페이지 index
     private boolean isEndOfPage = false; // 페이지 끝 flag
 


### PR DESCRIPTION
## 개요
* API호출 및 리스트 관련 코드 수정.

## 작업사항

* 영화 데이터를 불러오는 데 사용된 `Disposable`이 적절한 시점에 dispose되도록 수정했습니다.
1. CompositeDisposable`타입의 필드 추가.
2. 데이터를 불러오는 데 사용된 `Disposable`을 1-1 에서 생성한 필드에 add.
3. `MainActivity`의 `onDestroy`호출 시 dispose.
</br>

*  `subscribeOn`의 스케쥴러를 thread pool을 사용하는 `Schedulers.io`로 변경했습니다.
</br>

* `GlideUtil`의 `loadImageCenterCrop` 수정.
1. 디코드 된 이미지만 캐시되도록 `DiskCacheStrategy.RESOURCE` 로 변경했습니다.
2.  이미지 로드가 부드럽게 보이도록 트랜잭션을 추가했습니다. 
</br>

* 데이터 추가 로딩 시 멈추는 현상을 해결하기위해  `onScrollStateChanged`메소드를 수정했습니다.
1. 화면에 보이지 않는 아이템의 개수가 5개 이하일 경우, 추가로 데이터를 불러오도록 구현했습니다.

 
