### PR TITLE
같은 검색어로 여러번 요청하는 상황에 대한 처리

### DIFF
--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
@@ -118,4 +118,12 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
 
         customTabsIntent.launchUrl(this, Uri.parse(linkUrl));
     }
+
+    /**
+     * 같은 검색어로 검색을 재요청한 경우 presenter 에 의해 호출됨*/
+    @Override
+    public void onSameSearchKeyRequest() {
+        makeToast(getString(R.string.same_searchkey_request));
+    }
+
 }

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainContract.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainContract.java
@@ -12,6 +12,8 @@ public interface MainContract {
         void onSearchResultEmpty(String searchKey);
 
         void startMovieDetailPage(String linkUrl);
+
+        void onSameSearchKeyRequest();
     }
 
     interface Presenter extends BasePresenter {

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
@@ -55,6 +55,13 @@ public class MainPresenter implements MainContract.Presenter {
 
     @Override
     public void onSearchButtonClicked(String searchKey) {
+
+        // 이전에 검색한 Key와 다시 요청한 Key값이 경우
+        if(this.searchKey.equals(searchKey)){
+            view.onSameSearchKeyRequest();
+            return;
+        }
+
         this.searchKey = searchKey;
         loadItems(true);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="search_hint">검색어를 입력하세요.</string>
     <string name="search_submit">검색</string>
     <string name="search_result_empty">에 대한 검색결과가 없습니다.</string>
+    <string name="same_searchkey_request">같은 검색어 요청입니다.</string>
 </resources>


### PR DESCRIPTION
### 개요

-  같은 검색어로 재요성시 다시 api호출하던 문제 처리

### 상세구현
<img src="https://user-images.githubusercontent.com/21356399/51424224-530d2100-1c0e-11e9-8fc4-469be18ab631.gif" width="500" height="800" />

### 작업사항

-   `presenter`에 위치한 `private String searchKey`와 
     `onSearchButtonClicked`에 요청값으로 들어오는 `searchKey`값이 같은지 여부를 검사하여 처리
      (같으면 Toast Message를 띄워주고 return)