### PR TITLE
CustomTabsIntent 중복 에러 수정, 구분자 변경

### DIFF
--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainActivity.java
@@ -20,6 +20,7 @@ import com.example.yeseul.movieapp.view.BaseActivity;
 public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresenter> implements MainContract.View {
 
     private MovieListAdapter adapter;
+    private boolean customTabsState;
 
     @Override
     protected int getLayoutId() {
@@ -45,6 +46,15 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
 
         presenter.onViewCreated();
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if(!customTabsState) {
+            customTabsState = true;
+        }
+    }
+
 
     private void initView() {
 
@@ -111,11 +121,13 @@ public class MainActivity extends BaseActivity<ActivityMovieBinding, MainPresent
      * 영화 상세 정보 URL 로 연결 */
     @Override
     public void startMovieDetailPage(String linkUrl) {
+        if(customTabsState) {
+            customTabsState = false;
+            CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
+                    .setToolbarColor(getResources().getColor(R.color.colorPrimary))
+                    .build();
 
-        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
-                .setToolbarColor(getResources().getColor(R.color.colorPrimary))
-                .build();
-
-        customTabsIntent.launchUrl(this, Uri.parse(linkUrl));
+            customTabsIntent.launchUrl(this, Uri.parse(linkUrl));
+        }
     }
 }

--- a/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
+++ b/app/src/main/java/com/example/yeseul/movieapp/view/main/MainPresenter.java
@@ -98,6 +98,20 @@ public class MainPresenter implements MainContract.Presenter {
                         isEndOfPage = true;
                     }
 
+                    for(int i=0; i<movieList.size(); i++) {
+                        Movie movie = movieList.get(i);
+                        String director = movie.getDirector();
+                        String actor = movie.getActor();
+                        if(director.length() != 0) {
+                            director = director.substring(0, director.length() - 1).replaceAll("[|]", ",");
+                        }
+                        if(actor.length() != 0) {
+                            actor = actor.substring(0, actor.length() - 1).replaceAll("[|]", ",");
+                        }
+                        movie.setDirector(director);
+                        movie.setActor(actor);
+                    }
+
                     // 어댑터에 리스트 추가
                     adapterModel.addItems(movieList);
 


### PR DESCRIPTION
![appgif](https://user-images.githubusercontent.com/32831939/51425783-fc124680-1c23-11e9-894e-1d89b0c2e6c3.gif)　　<img src="https://user-images.githubusercontent.com/32831939/51425784-fe74a080-1c23-11e9-9d55-24b9656af4ad.png" width="300" height="600">

# 개요
1. CustomTabsIntent 에러 수정
2. 구분자 변경

# 작업 사항
### 1 
- 아이템을 빠르게 여러번 누를시 CustomTabsIntent가 여러개 열리던 에러를 customTabsState 변수를 통해 수정
### 2
- 감독과 출연 데이터 구분자를 |에서 ,로 변경하고 마지막 구분자 삭제

